### PR TITLE
fix go vet warning

### DIFF
--- a/config-center/config_center.go
+++ b/config-center/config_center.go
@@ -39,7 +39,7 @@ func InitConfigCenter() error {
 	var enableSSL bool
 	tlsConfig, tlsError := getTLSForClient()
 	if tlsError != nil {
-		lager.Logger.Errorf(tlsError, "Get %s.%s TLS config failed, err: %s.", Name, common.Consumer)
+		lager.Logger.Errorf(tlsError, "Get %s.%s TLS config failed, err:", Name, common.Consumer)
 		return tlsError
 	}
 
@@ -128,7 +128,7 @@ func getUniqueIDForDimInfo() string {
 	}
 
 	if len(serviceName) > maxValue {
-		lager.Logger.Errorf(nil, "exceeded max value ", maxValue, "for dimensionInfo ", serviceName, "with length ",
+		lager.Logger.Errorf(nil, "exceeded max value %d for dimensionInfo %s with length %d", maxValue, serviceName,
 			len(serviceName))
 		return ""
 	}
@@ -141,7 +141,7 @@ func getUniqueIDForDimInfo() string {
 	}
 
 	if !dimRegexVar.Match([]byte(serviceName)) {
-		lager.Logger.Errorf(nil, "invalid value for dimension info, doesnot setisfy the regular expression for dimInfo",
+		lager.Logger.Errorf(nil, "invalid value for dimension info, doesnot setisfy the regular expression for dimInfo:%s",
 			serviceName)
 		return ""
 	}

--- a/core/util/string/string.go
+++ b/core/util/string/string.go
@@ -76,7 +76,7 @@ func ClearStringMemory(src *string) {
 	len := MinInt(p.len, 32)
 	ptr := p.ptr
 	for idx := 0; idx < len; idx = idx + 1 {
-		b := (*byte)(unsafe.Pointer(ptr))
+		b := (*byte)(unsafe.Pointer(&ptr))
 		*b = 0
 		ptr++
 	}


### PR DESCRIPTION
When I use `go vet $(go list ./...| grep -v /vendor/| grep -v /third_party/)` scan our project ,it comes out  following warnings 
```bash
config-center/config_center.go:42: missing argument for Errorf("%s"): format reads arg 3, have only 2 args
config-center/config_center.go:131: no formatting directive in Errorf call
config-center/config_center.go:144: no formatting directive in Errorf call
exit status 1
core/util/string/string.go:79: possible misuse of unsafe.Pointer
exit status 1
```
This PR fix that 

Signed-off-by: WangQilin <qilin.wang@huawei.com>