### PR TITLE
decouple config center client, it should depend on go chassis package…

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1,7 +1,6 @@
 package bootstrap
 
 import (
-	"github.com/ServiceComb/go-chassis/config-center"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/metrics"
 )
@@ -49,9 +48,6 @@ func init() {
 	InstallPlugin("EE", BootstrapFunc(func() error {
 		return nil
 	}))
-
-	InstallPlugin("config_center",
-		BootstrapFunc(configcenter.InitConfigCenter))
 
 	InstallPlugin("metric", BootstrapFunc(metrics.Init))
 }

--- a/config-center/config_center.go
+++ b/config-center/config_center.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ServiceComb/go-chassis/core/lager"
 	chassisTLS "github.com/ServiceComb/go-chassis/core/tls"
 
+	"github.com/ServiceComb/go-chassis/bootstrap"
 	"github.com/ServiceComb/go-chassis/core/archaius"
 )
 
@@ -231,4 +232,8 @@ func enbledAutoDiscovery() bool {
 	}
 
 	return false
+}
+func init() {
+	bootstrap.InstallPlugin("config_center",
+		bootstrap.BootstrapFunc(InitConfigCenter))
 }

--- a/examples/discovery/client/main.go
+++ b/examples/discovery/client/main.go
@@ -1,19 +1,19 @@
 package main
 
 import (
-	"log"
-	"net/http"
-	"sync"
-
 	"github.com/ServiceComb/go-chassis"
 	_ "github.com/ServiceComb/go-chassis/bootstrap"
 	"github.com/ServiceComb/go-chassis/client/rest"
+	_ "github.com/ServiceComb/go-chassis/config-center"
 	"github.com/ServiceComb/go-chassis/core"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/examples/schemas/employ"
 	"github.com/ServiceComb/go-chassis/examples/schemas/helloworld"
 	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/metadata"
 	"golang.org/x/net/context"
+	"log"
+	"net/http"
+	"sync"
 )
 
 var wg sync.WaitGroup

--- a/examples/discovery/server/conf/monitoring.yaml
+++ b/examples/discovery/server/conf/monitoring.yaml
@@ -2,4 +2,4 @@ cse:
   metrics:
     apiPath: /metrics      # we can also give api path having prefix "/" ,like /adas/metrics
     enable: true
-    enableGoRuntimeMetrics: true
+    enableGoRuntimeMetrics: false

--- a/examples/discovery/server/main.go
+++ b/examples/discovery/server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/ServiceComb/go-chassis"
 	_ "github.com/ServiceComb/go-chassis/bootstrap"
+	_ "github.com/ServiceComb/go-chassis/config-center"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/examples/schemas"
 	serverOption "github.com/ServiceComb/go-chassis/third_party/forked/go-micro/server"

--- a/metrics/prometheusmetrics.go
+++ b/metrics/prometheusmetrics.go
@@ -27,7 +27,7 @@ import (
 
 // DefaultPrometheusSinker variable for default prometheus configurations
 var DefaultPrometheusSinker *PrometheusSinker
-var once sync.Once
+var onceInit sync.Once
 
 // PrometheusSinker is the struct for prometheus configuration parameters
 type PrometheusSinker struct {
@@ -40,7 +40,7 @@ type PrometheusSinker struct {
 
 // GetPrometheusSinker get prometheus configurations
 func GetPrometheusSinker(mr metrics.Registry, pr *prometheus.Registry) *PrometheusSinker {
-	once.Do(func() {
+	onceInit.Do(func() {
 		DefaultPrometheusSinker = NewPrometheusProvider(mr, pr, time.Second)
 	})
 	return DefaultPrometheusSinker

--- a/metrics/reportor.go
+++ b/metrics/reportor.go
@@ -1,0 +1,80 @@
+package metrics
+
+import (
+	"errors"
+	"github.com/ServiceComb/cse-collector"
+	"github.com/ServiceComb/go-chassis/core/archaius"
+	"github.com/ServiceComb/go-chassis/core/common"
+	"github.com/ServiceComb/go-chassis/core/config"
+	"github.com/ServiceComb/go-chassis/core/lager"
+	"github.com/ServiceComb/go-chassis/third_party/forked/afex/hystrix-go/hystrix/metric_collector"
+	"github.com/rcrowley/go-metrics"
+	"sync"
+	"time"
+)
+
+//Reporter receive a go-metrics registry and sink it to monitoring system
+type Reporter func(metrics.Registry) error
+
+//ErrDuplicated means you can not install reporter with same name
+var ErrDuplicated = errors.New("duplicated reporter")
+var reporterPlugins = make(map[string]Reporter)
+
+//InstallReporter install reporter implementation
+func InstallReporter(name string, reporter Reporter) error {
+	_, ok := reporterPlugins[name]
+	if ok {
+		return ErrDuplicated
+	}
+	reporterPlugins[name] = reporter
+	return nil
+}
+
+var onceEnable sync.Once
+
+//ReportMetricsToPrometheus report metrics to prometheus registry, you can use GetSystemPrometheusRegistry to get prometheus registry. by default chassis will report system metrics to prometheus
+func ReportMetricsToPrometheus(r metrics.Registry) error {
+	promConfig := GetPrometheusSinker(r, GetSystemPrometheusRegistry())
+	if archaius.GetBool("cse.metrics.enableGoRuntimeMetrics", true) {
+		onceEnable.Do(func() {
+			promConfig.EnableRunTimeMetrics()
+			lager.Logger.Info("Go Runtime Metrics is enabled")
+		})
+
+	}
+	go promConfig.UpdatePrometheusMetrics()
+	return nil
+}
+
+//metricCollector use go-metrics to send metrics to cse dashboard
+func reportMetricsToCSEDashboard(r metrics.Registry) error {
+	metricCollector.Registry.Register(metricsink.NewCseCollector)
+
+	monitorServerURL, err := getMonitorEndpoint()
+	if err != nil {
+		lager.Logger.Warn("Get Monitoring URL failed, CSE monitoring function disabled", err)
+		return nil
+	}
+
+	tlsConfig, tlsError := getTLSForClient(monitorServerURL)
+	if tlsError != nil {
+		lager.Logger.Errorf(tlsError, "Get %s.%s TLS config failed.", Name, common.Consumer)
+		return tlsError
+	}
+
+	metricsink.InitializeCseCollector(&metricsink.CseCollectorConfig{
+		CseMonitorAddr: monitorServerURL,
+		Header:         getAuthHeaders(),
+		TimeInterval:   time.Second * 2,
+		TLSConfig:      tlsConfig,
+	}, r, config.GlobalDefinition.AppID, config.SelfVersion, config.SelfServiceName)
+	lager.Logger.Infof("Started sending metric Data to Monitor Server : %s", monitorServerURL)
+	return nil
+}
+
+//TODO ReportMetricsToOpenTSDB use go-metrics reporter to send metrics to opentsdb
+
+func init() {
+	InstallReporter("Prometheus", ReportMetricsToPrometheus)
+	InstallReporter("CSE Monitoring", reportMetricsToCSEDashboard)
+}


### PR DESCRIPTION
…, go chassis does not depend on config center package

extract new func interface Reporter