### PR TITLE
reorg sequences of import packages

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ServiceComb/auth"
 	"github.com/ServiceComb/go-chassis/core/archaius"
 	"github.com/ServiceComb/go-chassis/core/common"
 	"github.com/ServiceComb/go-chassis/core/config"
@@ -18,6 +17,8 @@ import (
 	"github.com/ServiceComb/go-chassis/core/goplugin"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/security"
+
+	"github.com/ServiceComb/auth"
 	yaml "gopkg.in/yaml.v2"
 )
 

--- a/client/highway/highway_client.go
+++ b/client/highway/highway_client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ServiceComb/go-chassis/core/client"
 	"github.com/ServiceComb/go-chassis/core/config"
 	"github.com/ServiceComb/go-chassis/core/lager"
+
 	microClient "github.com/ServiceComb/go-chassis/third_party/forked/go-micro/client"
 	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/codec"
 	"golang.org/x/net/context"

--- a/client/highway/worker.go
+++ b/client/highway/worker.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ServiceComb/go-chassis/client/highway/pb"
 	"github.com/ServiceComb/go-chassis/core/lager"
+
 	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/client"
 	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/metadata"
 	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/transport"

--- a/client/rest/rest_client.go
+++ b/client/rest/rest_client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ServiceComb/go-chassis/core/client"
 	"github.com/ServiceComb/go-chassis/core/common"
 	"github.com/ServiceComb/go-chassis/core/loadbalance"
+
 	microClient "github.com/ServiceComb/go-chassis/third_party/forked/go-micro/client"
 	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/codec"
 	"github.com/ServiceComb/go-chassis/third_party/forked/valyala/fasthttp"

--- a/config-center/config_center.go
+++ b/config-center/config_center.go
@@ -8,21 +8,20 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ServiceComb/go-archaius"
-	// go-archaius package is imported for to initialize the config-center configurations
-	_ "github.com/ServiceComb/go-archaius"
-	"github.com/ServiceComb/go-archaius/core"
-	"github.com/ServiceComb/go-archaius/sources/configcenter-source"
-	"github.com/ServiceComb/go-cc-client"
-	"github.com/ServiceComb/go-cc-client/member-discovery"
+	"github.com/ServiceComb/go-chassis/bootstrap"
+	"github.com/ServiceComb/go-chassis/core/archaius"
 	"github.com/ServiceComb/go-chassis/core/common"
 	"github.com/ServiceComb/go-chassis/core/config"
 	"github.com/ServiceComb/go-chassis/core/endpoint-discovery"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	chassisTLS "github.com/ServiceComb/go-chassis/core/tls"
 
-	"github.com/ServiceComb/go-chassis/bootstrap"
-	"github.com/ServiceComb/go-chassis/core/archaius"
+	// go-archaius package is imported for to initialize the config-center configurations
+	"github.com/ServiceComb/go-archaius"
+	"github.com/ServiceComb/go-archaius/core"
+	"github.com/ServiceComb/go-archaius/sources/configcenter-source"
+	"github.com/ServiceComb/go-cc-client"
+	"github.com/ServiceComb/go-cc-client/member-discovery"
 )
 
 const (

--- a/core/archaius/yaml.go
+++ b/core/archaius/yaml.go
@@ -1,9 +1,11 @@
 package archaius
 
 import (
-	"github.com/ServiceComb/go-archaius/core"
-	"github.com/ServiceComb/go-chassis/core/lager"
 	"os"
+
+	"github.com/ServiceComb/go-chassis/core/lager"
+
+	"github.com/ServiceComb/go-archaius/core"
 )
 
 // PathExist to check the existence of the file path

--- a/core/client/client_manager.go
+++ b/core/client/client_manager.go
@@ -1,18 +1,19 @@
 package client
 
 import (
-	"strings"
-
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/ServiceComb/go-chassis/core/common"
 	"github.com/ServiceComb/go-chassis/core/config"
 	"github.com/ServiceComb/go-chassis/core/config/model"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	chassisTLS "github.com/ServiceComb/go-chassis/core/tls"
 	"github.com/ServiceComb/go-chassis/core/transport"
+
 	microClient "github.com/ServiceComb/go-chassis/third_party/forked/go-micro/client"
 	microTransport "github.com/ServiceComb/go-chassis/third_party/forked/go-micro/transport"
-	"sync"
 )
 
 var clients = make(map[string]map[string]microClient.Client)

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ServiceComb/go-chassis/core/config/schema"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/util/fileutil"
+
 	"gopkg.in/yaml.v2"
 )
 

--- a/core/config/router_config.go
+++ b/core/config/router_config.go
@@ -2,14 +2,16 @@ package config
 
 import (
 	"encoding/json"
-	"github.com/ServiceComb/go-chassis/core/archaius"
-	"github.com/ServiceComb/go-chassis/core/lager"
-	"github.com/ServiceComb/go-chassis/util/fileutil"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/ServiceComb/go-chassis/core/archaius"
+	"github.com/ServiceComb/go-chassis/core/lager"
+	"github.com/ServiceComb/go-chassis/util/fileutil"
+
+	"gopkg.in/yaml.v2"
 )
 
 // constant for route rule keys

--- a/core/endpoint-discovery/endpoint.go
+++ b/core/endpoint-discovery/endpoint.go
@@ -3,10 +3,11 @@ package endpoint
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/ServiceComb/go-chassis/core/config"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/core/registry"
-	"strings"
 )
 
 // GetEndpointFromServiceCenter is used to get the endpoint based on appID, microservice and version

--- a/core/fault/fault_injection.go
+++ b/core/fault/fault_injection.go
@@ -3,9 +3,10 @@ package fault
 import (
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/ServiceComb/go-chassis/core/config/model"
 	"github.com/ServiceComb/go-chassis/core/invocation"
-	"time"
 )
 
 var (

--- a/core/handler/bizkeeper_consumer_handle.go
+++ b/core/handler/bizkeeper_consumer_handle.go
@@ -1,12 +1,14 @@
 package handler
 
 import (
+	"strings"
+
 	"github.com/ServiceComb/go-chassis/core/archaius"
 	"github.com/ServiceComb/go-chassis/core/common"
 	"github.com/ServiceComb/go-chassis/core/invocation"
 	"github.com/ServiceComb/go-chassis/core/lager"
+
 	"github.com/ServiceComb/go-chassis/third_party/forked/afex/hystrix-go/hystrix"
-	"strings"
 )
 
 // constant for bizkeeper-consumer

--- a/core/handler/bizkeeper_provider_handler.go
+++ b/core/handler/bizkeeper_provider_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/ServiceComb/go-chassis/core/common"
 	"github.com/ServiceComb/go-chassis/core/invocation"
+
 	"github.com/ServiceComb/go-chassis/third_party/forked/afex/hystrix-go/hystrix"
 )
 

--- a/core/handler/fault_inject_handler.go
+++ b/core/handler/fault_inject_handler.go
@@ -2,15 +2,17 @@ package handler
 
 import (
 	"errors"
+	"net/http"
+	"strings"
+
 	"github.com/ServiceComb/go-chassis/client/rest"
 	"github.com/ServiceComb/go-chassis/core/archaius"
 	"github.com/ServiceComb/go-chassis/core/config/model"
 	"github.com/ServiceComb/go-chassis/core/fault"
 	"github.com/ServiceComb/go-chassis/core/invocation"
 	"github.com/ServiceComb/go-chassis/core/lager"
+
 	"github.com/ServiceComb/go-chassis/third_party/forked/valyala/fasthttp"
-	"net/http"
-	"strings"
 )
 
 // constant for fault handler name

--- a/core/handler/handler.go
+++ b/core/handler/handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"errors"
 	"fmt"
+
 	"github.com/ServiceComb/go-chassis/core/invocation"
 	"github.com/ServiceComb/go-chassis/core/util/string"
 )

--- a/core/handler/handler_chain.go
+++ b/core/handler/handler_chain.go
@@ -2,12 +2,12 @@ package handler
 
 import (
 	"errors"
-
 	"fmt"
+	"strings"
+
 	"github.com/ServiceComb/go-chassis/core/common"
 	"github.com/ServiceComb/go-chassis/core/invocation"
 	"github.com/ServiceComb/go-chassis/core/lager"
-	"strings"
 )
 
 var errEmptyChain = errors.New("Chain can not be empty")

--- a/core/handler/loadbalance_handler.go
+++ b/core/handler/loadbalance_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ServiceComb/go-chassis/core/invocation"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/core/loadbalance"
+
 	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/selector"
 	"github.com/ServiceComb/go-chassis/third_party/forked/valyala/fasthttp"
 	"github.com/cenkalti/backoff"

--- a/core/handler/router_handler.go
+++ b/core/handler/router_handler.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ServiceComb/go-chassis/core/invocation"
 	"github.com/ServiceComb/go-chassis/core/registry"
 	"github.com/ServiceComb/go-chassis/core/route"
+
 	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/metadata"
 )
 

--- a/core/handler/tracing_handler.go
+++ b/core/handler/tracing_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/metadata"
 	"github.com/ServiceComb/go-chassis/third_party/forked/valyala/fasthttp"
 	"github.com/ServiceComb/go-chassis/util/iputil"
+
 	"github.com/emicklei/go-restful"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"

--- a/core/handler/transport_handler.go
+++ b/core/handler/transport_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/core/loadbalance"
 	"github.com/ServiceComb/go-chassis/session"
+
 	clientOption "github.com/ServiceComb/go-chassis/third_party/forked/go-micro/client"
 	microClient "github.com/ServiceComb/go-chassis/third_party/forked/go-micro/client"
 )

--- a/core/invocation/invocation.go
+++ b/core/invocation/invocation.go
@@ -2,7 +2,9 @@ package invocation
 
 import (
 	"context"
+
 	"github.com/ServiceComb/go-chassis/core/config"
+
 	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/selector"
 )
 

--- a/core/lager/lager.go
+++ b/core/lager/lager.go
@@ -1,13 +1,15 @@
 package lager
 
 import (
-	"github.com/ServiceComb/go-chassis/core/common"
-	"github.com/ServiceComb/paas-lager"
-	"github.com/ServiceComb/paas-lager/third_party/forked/cloudfoundry/lager"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/ServiceComb/go-chassis/core/common"
+
+	"github.com/ServiceComb/paas-lager"
+	"github.com/ServiceComb/paas-lager/third_party/forked/cloudfoundry/lager"
 )
 
 // constant values for logrotate parameters

--- a/core/lager/logrotate.go
+++ b/core/lager/logrotate.go
@@ -18,7 +18,6 @@ package lager
 import (
 	"archive/zip"
 	"fmt"
-	"github.com/ServiceComb/go-chassis/core/common"
 	"io"
 	"os"
 	"path/filepath"
@@ -26,6 +25,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/ServiceComb/go-chassis/core/common"
 )
 
 var pathReplacer *strings.Replacer

--- a/core/loadbalance/default.go
+++ b/core/loadbalance/default.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ServiceComb/go-chassis/core/config"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/core/registry"
+
 	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/selector"
 )
 

--- a/core/loadbalance/filter.go
+++ b/core/loadbalance/filter.go
@@ -3,6 +3,7 @@ package loadbalance
 import (
 	"github.com/ServiceComb/go-chassis/core/config"
 	"github.com/ServiceComb/go-chassis/core/registry"
+
 	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/selector"
 )
 

--- a/core/loadbalance/latency_strategy.go
+++ b/core/loadbalance/latency_strategy.go
@@ -1,12 +1,14 @@
 package loadbalance
 
 import (
-	"github.com/ServiceComb/go-chassis/core/registry"
-	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/selector"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/ServiceComb/go-chassis/core/registry"
+
+	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/selector"
 )
 
 // ByDuration is for calculating the duration

--- a/core/loadbalance/selector.go
+++ b/core/loadbalance/selector.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ServiceComb/go-chassis/core/archaius"
 	"github.com/ServiceComb/go-chassis/core/config"
 	"github.com/ServiceComb/go-chassis/core/lager"
+
 	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/selector"
 )
 

--- a/core/loadbalance/session_stickiness_strategy.go
+++ b/core/loadbalance/session_stickiness_strategy.go
@@ -1,11 +1,12 @@
 package loadbalance
 
 import (
-	"github.com/ServiceComb/go-chassis/core/registry"
-	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/selector"
-
-	"github.com/ServiceComb/go-chassis/session"
 	"sync"
+
+	"github.com/ServiceComb/go-chassis/core/registry"
+	"github.com/ServiceComb/go-chassis/session"
+
+	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/selector"
 )
 
 var (

--- a/core/loadbalance/strategy.go
+++ b/core/loadbalance/strategy.go
@@ -1,12 +1,13 @@
 package loadbalance
 
 import (
+	"fmt"
 	"math/rand"
 	"time"
 
-	"fmt"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/core/registry"
+
 	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/selector"
 )
 

--- a/core/options.go
+++ b/core/options.go
@@ -1,10 +1,12 @@
 package core
 
 import (
+	"time"
+
 	"github.com/ServiceComb/go-chassis/core/common"
 	"github.com/ServiceComb/go-chassis/core/invocation"
+
 	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/selector"
-	"time"
 )
 
 // Options is a struct to stores information about chain name, filters, and their invocation options

--- a/core/provider/provider.go
+++ b/core/provider/provider.go
@@ -1,8 +1,9 @@
 package provider
 
 import (
-	"github.com/ServiceComb/go-chassis/core/invocation"
 	"reflect"
+
+	"github.com/ServiceComb/go-chassis/core/invocation"
 )
 
 // Provider is the interface for schema methods

--- a/core/provider/provider_manager.go
+++ b/core/provider/provider_manager.go
@@ -2,8 +2,9 @@ package provider
 
 import (
 	"fmt"
-	"github.com/ServiceComb/go-chassis/core/lager"
 	"log"
+
+	"github.com/ServiceComb/go-chassis/core/lager"
 )
 
 // plugin name and schemas map

--- a/core/qpslimiter/consumer_qps_operation_meta.go
+++ b/core/qpslimiter/consumer_qps_operation_meta.go
@@ -1,8 +1,9 @@
 package qpslimiter
 
 import (
-	"github.com/ServiceComb/go-chassis/core/invocation"
 	"strings"
+
+	"github.com/ServiceComb/go-chassis/core/invocation"
 )
 
 // OperationMeta operation meta struct

--- a/core/registry/bootstrap.go
+++ b/core/registry/bootstrap.go
@@ -1,12 +1,13 @@
 package registry
 
 import (
+	"os"
+
 	"github.com/ServiceComb/go-chassis/core/config"
 	"github.com/ServiceComb/go-chassis/core/config/schema"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/core/metadata"
 	"github.com/ServiceComb/go-sc-client/model"
-	"os"
 )
 
 // microServiceDependencies micro-service dependencies

--- a/core/registry/file/file.go
+++ b/core/registry/file/file.go
@@ -2,8 +2,10 @@ package file
 
 import (
 	"fmt"
+
 	"github.com/ServiceComb/go-chassis/core/registry"
 	"github.com/ServiceComb/go-chassis/core/registry/servicecenter"
+
 	"github.com/ServiceComb/go-sc-client/model"
 )
 

--- a/core/registry/file/file_client.go
+++ b/core/registry/file/file_client.go
@@ -3,13 +3,15 @@ package file
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ServiceComb/go-chassis/core/lager"
-	"github.com/ServiceComb/go-chassis/util/fileutil"
-	"github.com/ServiceComb/go-sc-client/model"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/ServiceComb/go-chassis/core/lager"
+	"github.com/ServiceComb/go-chassis/util/fileutil"
+
+	"github.com/ServiceComb/go-sc-client/model"
 )
 
 const (

--- a/core/registry/heartbeat.go
+++ b/core/registry/heartbeat.go
@@ -2,14 +2,16 @@ package registry
 
 import (
 	"fmt"
-	"github.com/ServiceComb/go-chassis/core/config"
-	"github.com/ServiceComb/go-chassis/core/lager"
-	client "github.com/ServiceComb/go-sc-client"
-	"github.com/ServiceComb/go-sc-client/model"
-	pb "github.com/ServiceComb/go-sc-client/model"
 	"os"
 	"sync"
 	"time"
+
+	"github.com/ServiceComb/go-chassis/core/config"
+	"github.com/ServiceComb/go-chassis/core/lager"
+
+	client "github.com/ServiceComb/go-sc-client"
+	"github.com/ServiceComb/go-sc-client/model"
+	pb "github.com/ServiceComb/go-sc-client/model"
 )
 
 // DefaultRetryTime default retry time

--- a/core/registry/mock/mock.go
+++ b/core/registry/mock/mock.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"github.com/ServiceComb/go-chassis/core/registry"
+
 	"github.com/ServiceComb/go-sc-client/model"
 	"github.com/stretchr/testify/mock"
 )

--- a/core/registry/servicecenter/cache.go
+++ b/core/registry/servicecenter/cache.go
@@ -1,17 +1,19 @@
 package servicecenter
 
 import (
+	"net/url"
+	"strings"
+	"time"
+
 	"github.com/ServiceComb/go-chassis/core/archaius"
 	"github.com/ServiceComb/go-chassis/core/common"
 	"github.com/ServiceComb/go-chassis/core/config"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/core/registry"
+
 	client "github.com/ServiceComb/go-sc-client"
 	"github.com/ServiceComb/go-sc-client/model"
 	cache "github.com/patrickmn/go-cache"
-	"net/url"
-	"strings"
-	"time"
 )
 
 // constant values for default expiration time, and refresh interval

--- a/core/registry/servicecenter/sc_convertor.go
+++ b/core/registry/servicecenter/sc_convertor.go
@@ -2,6 +2,7 @@ package servicecenter
 
 import (
 	"github.com/ServiceComb/go-chassis/core/registry"
+
 	"github.com/ServiceComb/go-sc-client/model"
 )
 

--- a/core/registry/servicecenter/servicecenter.go
+++ b/core/registry/servicecenter/servicecenter.go
@@ -2,9 +2,11 @@ package servicecenter
 
 import (
 	"fmt"
+
 	"github.com/ServiceComb/go-chassis/core/config"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/core/registry"
+
 	client "github.com/ServiceComb/go-sc-client"
 	"github.com/ServiceComb/go-sc-client/model"
 	"gopkg.in/yaml.v2"

--- a/core/registry/util.go
+++ b/core/registry/util.go
@@ -2,12 +2,12 @@ package registry
 
 import (
 	"net"
+	"net/url"
 	"strings"
 
 	"github.com/ServiceComb/go-chassis/core/config/model"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/util/iputil"
-	"net/url"
 )
 
 const protocolSymbol = "://"

--- a/core/rest_invoker.go
+++ b/core/rest_invoker.go
@@ -2,12 +2,14 @@ package core
 
 import (
 	"fmt"
+
 	"github.com/ServiceComb/go-chassis/client/rest"
 	"github.com/ServiceComb/go-chassis/core/common"
 	"github.com/ServiceComb/go-chassis/core/config"
 	"github.com/ServiceComb/go-chassis/core/handler"
 	"github.com/ServiceComb/go-chassis/core/invocation"
 	"github.com/ServiceComb/go-chassis/core/lager"
+
 	"golang.org/x/net/context"
 )
 

--- a/core/route/router.go
+++ b/core/route/router.go
@@ -2,13 +2,14 @@ package router
 
 import (
 	"errors"
+	"regexp"
+	"strconv"
+	"sync"
+
 	"github.com/ServiceComb/go-chassis/core/common"
 	"github.com/ServiceComb/go-chassis/core/config"
 	"github.com/ServiceComb/go-chassis/core/invocation"
 	"github.com/ServiceComb/go-chassis/core/registry"
-	"regexp"
-	"strconv"
-	"sync"
 )
 
 var dests map[string][]*config.RouteRule

--- a/core/rpc_invoker.go
+++ b/core/rpc_invoker.go
@@ -1,14 +1,16 @@
 package core
 
 import (
+	"sync"
+
 	"github.com/ServiceComb/go-chassis/core/common"
 	"github.com/ServiceComb/go-chassis/core/config"
 	"github.com/ServiceComb/go-chassis/core/handler"
 	"github.com/ServiceComb/go-chassis/core/invocation"
 	"github.com/ServiceComb/go-chassis/core/lager"
+
 	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/metadata"
 	"golang.org/x/net/context"
-	"sync"
 )
 
 // RPCInvoker is rpc invoker

--- a/core/server/server_manager.go
+++ b/core/server/server_manager.go
@@ -11,10 +11,11 @@ import (
 	"github.com/ServiceComb/go-chassis/core/registry"
 	chassisTLS "github.com/ServiceComb/go-chassis/core/tls"
 	"github.com/ServiceComb/go-chassis/core/transport"
+	"github.com/ServiceComb/go-chassis/util/iputil"
+
 	"github.com/ServiceComb/go-chassis/third_party/forked/go-micro/codec"
 	microServer "github.com/ServiceComb/go-chassis/third_party/forked/go-micro/server"
 	microTransport "github.com/ServiceComb/go-chassis/third_party/forked/go-micro/transport"
-	"github.com/ServiceComb/go-chassis/util/iputil"
 )
 
 //NewFunc returns a server

--- a/core/tls/tls.go
+++ b/core/tls/tls.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ServiceComb/go-chassis/core/common"
 	"github.com/ServiceComb/go-chassis/core/config"
 	secCommon "github.com/ServiceComb/go-chassis/security/common"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 

--- a/core/tracing/carrier.go
+++ b/core/tracing/carrier.go
@@ -2,6 +2,7 @@ package tracing
 
 import (
 	"github.com/ServiceComb/go-chassis/client/rest"
+
 	"github.com/ServiceComb/go-chassis/third_party/forked/valyala/fasthttp"
 )
 

--- a/core/tracing/tracer_manager.go
+++ b/core/tracing/tracer_manager.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ServiceComb/go-chassis/core/config/schema"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/util/iputil"
+
 	"github.com/opentracing/opentracing-go"
 	zipkin "github.com/openzipkin/zipkin-go-opentracing"
 )

--- a/core/transport/transport_manager.go
+++ b/core/transport/transport_manager.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/ServiceComb/go-chassis/core/lager"
+
 	microTransport "github.com/ServiceComb/go-chassis/third_party/forked/go-micro/transport"
 )
 

--- a/eventlistener/circuit_breaker_event_listener.go
+++ b/eventlistener/circuit_breaker_event_listener.go
@@ -1,12 +1,14 @@
 package eventlistener
 
 import (
-	"github.com/ServiceComb/go-archaius/core"
-	"github.com/ServiceComb/go-chassis/core/common"
-	"github.com/ServiceComb/go-chassis/core/lager"
-	"github.com/ServiceComb/go-chassis/third_party/forked/afex/hystrix-go/hystrix"
 	"regexp"
 	"strings"
+
+	"github.com/ServiceComb/go-chassis/core/common"
+	"github.com/ServiceComb/go-chassis/core/lager"
+
+	"github.com/ServiceComb/go-archaius/core"
+	"github.com/ServiceComb/go-chassis/third_party/forked/afex/hystrix-go/hystrix"
 )
 
 // constants for consumer isolation, circuit breaker, fallback keys

--- a/eventlistener/event_register.go
+++ b/eventlistener/event_register.go
@@ -1,8 +1,9 @@
 package eventlistener
 
 import (
-	"github.com/ServiceComb/go-archaius/core"
 	"github.com/ServiceComb/go-chassis/core/archaius"
+
+	"github.com/ServiceComb/go-archaius/core"
 )
 
 //RegisterKeys registers a config key to the archaius

--- a/eventlistener/loadbalance_event_register.go
+++ b/eventlistener/loadbalance_event_register.go
@@ -1,9 +1,10 @@
 package eventlistener
 
 import (
-	"github.com/ServiceComb/go-archaius/core"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/core/loadbalance"
+
+	"github.com/ServiceComb/go-archaius/core"
 )
 
 // constants for loadbalance strategy name, and timeout

--- a/eventlistener/qps_event_listener.go
+++ b/eventlistener/qps_event_listener.go
@@ -1,10 +1,12 @@
 package eventlistener
 
 import (
-	"github.com/ServiceComb/go-archaius/core"
+	"strings"
+
 	"github.com/ServiceComb/go-chassis/core/common"
 	"github.com/ServiceComb/go-chassis/core/qpslimiter"
-	"strings"
+
+	"github.com/ServiceComb/go-archaius/core"
 )
 
 const (

--- a/eventlistener/router_event_listener.go
+++ b/eventlistener/router_event_listener.go
@@ -2,12 +2,14 @@ package eventlistener
 
 import (
 	"encoding/json"
-	"github.com/ServiceComb/go-archaius/core"
+	"strings"
+
 	"github.com/ServiceComb/go-chassis/core/common"
 	"github.com/ServiceComb/go-chassis/core/config"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/core/route"
-	"strings"
+
+	"github.com/ServiceComb/go-archaius/core"
 )
 
 // constants for dark launch key and prefix

--- a/metrics/cse_monitoring.go
+++ b/metrics/cse_monitoring.go
@@ -3,13 +3,14 @@ package metrics
 import (
 	"crypto/tls"
 	"fmt"
+	"net/http"
+	"net/url"
+
 	"github.com/ServiceComb/go-chassis/core/common"
 	"github.com/ServiceComb/go-chassis/core/config"
 	"github.com/ServiceComb/go-chassis/core/endpoint-discovery"
 	"github.com/ServiceComb/go-chassis/core/lager"
 	chassisTLS "github.com/ServiceComb/go-chassis/core/tls"
-	"net/http"
-	"net/url"
 )
 
 func getTLSForClient(monitorURL string) (*tls.Config, error) {

--- a/metrics/metric.go
+++ b/metrics/metric.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/ServiceComb/go-chassis/core/lager"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rcrowley/go-metrics"
-	"sync"
 )
 
 var errMonitoringFail = errors.New("Con not report metrics to CSE monitoring service")

--- a/metrics/prometheusmetrics.go
+++ b/metrics/prometheusmetrics.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/ServiceComb/go-chassis/core/config"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rcrowley/go-metrics"
 )

--- a/metrics/reportor.go
+++ b/metrics/reportor.go
@@ -2,15 +2,17 @@ package metrics
 
 import (
 	"errors"
-	"github.com/ServiceComb/cse-collector"
+	"sync"
+	"time"
+
 	"github.com/ServiceComb/go-chassis/core/archaius"
 	"github.com/ServiceComb/go-chassis/core/common"
 	"github.com/ServiceComb/go-chassis/core/config"
 	"github.com/ServiceComb/go-chassis/core/lager"
+
+	"github.com/ServiceComb/cse-collector"
 	"github.com/ServiceComb/go-chassis/third_party/forked/afex/hystrix-go/hystrix/metric_collector"
 	"github.com/rcrowley/go-metrics"
-	"sync"
-	"time"
 )
 
 //Reporter receive a go-metrics registry and sink it to monitoring system

--- a/security/common/common.go
+++ b/security/common/common.go
@@ -1,14 +1,14 @@
 package common
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"strings"
 
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/pem"
 	"github.com/ServiceComb/go-chassis/core/common"
 	"github.com/ServiceComb/go-chassis/core/util/string"
 	"github.com/ServiceComb/go-chassis/security"

--- a/server/restful/context.go
+++ b/server/restful/context.go
@@ -2,8 +2,9 @@ package restful
 
 import (
 	"context"
-	"github.com/emicklei/go-restful"
 	"net/http"
+
+	"github.com/emicklei/go-restful"
 )
 
 //Context is a struct which has both request and response objects

--- a/server/restful/restful_server.go
+++ b/server/restful/restful_server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ServiceComb/go-chassis/core/lager"
 	"github.com/ServiceComb/go-chassis/core/server"
 	"github.com/ServiceComb/go-chassis/metrics"
+
 	microServer "github.com/ServiceComb/go-chassis/third_party/forked/go-micro/server"
 	"github.com/emicklei/go-restful"
 	"github.com/emicklei/go-restful-swagger12"

--- a/session/session_manager.go
+++ b/session/session_manager.go
@@ -3,14 +3,16 @@ package session
 import (
 	"errors"
 	"fmt"
-	"github.com/ServiceComb/go-chassis/core/common"
-	"github.com/ServiceComb/go-chassis/core/invocation"
-	"github.com/ServiceComb/go-chassis/core/lager"
-	"github.com/ServiceComb/go-chassis/third_party/forked/valyala/fasthttp"
-	cache "github.com/patrickmn/go-cache"
 	"math/rand"
 	"strings"
 	"time"
+
+	"github.com/ServiceComb/go-chassis/core/common"
+	"github.com/ServiceComb/go-chassis/core/invocation"
+	"github.com/ServiceComb/go-chassis/core/lager"
+
+	"github.com/ServiceComb/go-chassis/third_party/forked/valyala/fasthttp"
+	cache "github.com/patrickmn/go-cache"
 )
 
 // ErrResponseNil used for to represent the error response, when it is nil


### PR DESCRIPTION
This PR reorg sequences of import packages to follow general rules:
offical standard package -> go-chassis internal package -> third_party package

