### PR TITLE
Add event key successiveFailedTimes to watched keys

### DIFF
--- a/eventlistener/event_register.go
+++ b/eventlistener/event_register.go
@@ -1,9 +1,8 @@
 package eventlistener
 
 import (
-	"github.com/ServiceComb/go-chassis/core/archaius"
-
 	"github.com/ServiceComb/go-archaius/core"
+	"github.com/ServiceComb/go-chassis/core/archaius"
 )
 
 //RegisterKeys registers a config key to the archaius
@@ -20,8 +19,7 @@ func Init() {
 
 	RegisterKeys(qpsEventListener, QPSLimitKey)
 	RegisterKeys(circuitBreakerEventListener, ConsumerFallbackKey, ConsumerFallbackPolicyKey, ConsumerIsolationKey, ConsumerCircuitbreakerKey)
-	RegisterKeys(lbEventListener, LbStrategyNameKey)
-	RegisterKeys(lbEventListener, LbStrategyTimeoutKey)
+	RegisterKeys(lbEventListener, LoadBalanceKey)
 	RegisterKeys(&DarkLaunchEventListener{}, DarkLaunchKey)
 
 }

--- a/eventlistener/loadbalance_event_listener.go
+++ b/eventlistener/loadbalance_event_listener.go
@@ -10,11 +10,10 @@ import (
 
 // constants for loadbalance strategy name, and timeout
 const (
-	//LbStrategyNameKey & LbStrategyTimeoutKey are variables of type string
-	LbStrategyNameKey    = "cse.loadbalance.strategy.name"
-	LbStrategyTimeoutKey = "cse.loadbalance.SessionStickinessRule.sessionTimeoutInSeconds"
-	Update               = "update"
-	Delete               = "delete"
+	//LoadBalanceKey is variable of type string that matches load balancing events
+	LoadBalanceKey = "^cse\\.loadbalance\\."
+	Update         = "update"
+	Delete         = "delete"
 )
 
 //LoadbalanceEventListener is a struct


### PR DESCRIPTION
Update of loadbalance successiveFailedTimes configuration can be missed if it is not watched.