### PR TITLE
set inv ctx to restful handler 

### DIFF
--- a/core/handler/tracing_handler.go
+++ b/core/handler/tracing_handler.go
@@ -251,9 +251,12 @@ func (t *TracingConsumerHandler) Name() string {
 
 func (t *TracingConsumerHandler) getTracer(i *invocation.Invocation) opentracing.Tracer {
 	caller := common.DefaultValue
-	if c, ok := i.Metadata[common.CallerKey].(string); ok && c != "" {
-		caller = c + ":" + runtime.HostName
+	if i.Metadata != nil {
+		if c, ok := i.Metadata[common.CallerKey].(string); ok && c != "" {
+			caller = c + ":" + runtime.HostName
+		}
 	}
+
 	return tracing.GetTracer(caller)
 }
 

--- a/core/invocation/invocation_test.go
+++ b/core/invocation/invocation_test.go
@@ -3,12 +3,20 @@ package invocation_test
 import (
 	"context"
 	"github.com/ServiceComb/go-chassis/core/invocation"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestChain(t *testing.T) {
 	var inv = new(invocation.Invocation)
 	inv.Endpoint = "1.2.3.4"
+}
+func TestInvocation_Headers(t *testing.T) {
+	inv := invocation.New(context.TODO())
+	inv.SetMetadata("a", "1")
+	inv.SetHeader("asd", "123")
+	assert.Equal(t, "123", inv.Headers()["asd"])
+	assert.Equal(t, "1", inv.Metadata["a"])
 }
 
 /*

--- a/core/options.go
+++ b/core/options.go
@@ -137,6 +137,9 @@ func wrapInvocationWithOpts(i *invocation.Invocation, opts InvokeOptions) {
 	i.Protocol = opts.Protocol
 	i.Strategy = opts.StrategyFunc
 	i.Filters = opts.Filters
-	i.Metadata = opts.Metadata
+	if opts.Metadata != nil {
+		i.Metadata = opts.Metadata
+	}
+
 	i.RouteTags = opts.RouteTags
 }

--- a/core/rest_invoker.go
+++ b/core/rest_invoker.go
@@ -40,7 +40,7 @@ func (ri *RestInvoker) ContextDo(ctx context.Context, req *rest.Request, options
 
 	resp := rest.NewResponse()
 
-	inv := invocation.CreateConsumerInvocation()
+	inv := invocation.New(ctx)
 	wrapInvocationWithOpts(inv, opts)
 	inv.MicroServiceName = req.GetRequest().Host
 	// TODO load from openAPI schema
@@ -48,13 +48,9 @@ func (ri *RestInvoker) ContextDo(ctx context.Context, req *rest.Request, options
 	// inv.OperationID = operationID
 	inv.Args = req
 	inv.Reply = resp
-	inv.Ctx = ctx
 	inv.URLPathFormat = req.Req.URL.Path
 
-	if inv.Metadata == nil {
-		inv.Metadata = make(map[string]interface{})
-	}
-	inv.Metadata[common.RestMethod] = req.GetMethod()
+	inv.SetMetadata(common.RestMethod, req.GetMethod())
 
 	err := ri.invoke(inv)
 	return resp, err

--- a/core/rpc_invoker.go
+++ b/core/rpc_invoker.go
@@ -37,13 +37,12 @@ func (ri *RPCInvoker) Invoke(ctx context.Context, microServiceName, schemaID, op
 		opts.Protocol = common.ProtocolHighway
 	}
 
-	i := invocation.CreateConsumerInvocation()
+	i := invocation.New(ctx)
 	wrapInvocationWithOpts(i, opts)
 	i.MicroServiceName = microServiceName
 	i.SchemaID = schemaID
 	i.OperationID = operationID
 	i.Args = arg
 	i.Reply = reply
-	i.Ctx = ctx
 	return ri.invoke(i)
 }

--- a/server/restful/context.go
+++ b/server/restful/context.go
@@ -95,3 +95,8 @@ func (bs *Context) ReadRestfulRequest() *restful.Request {
 func (bs *Context) ReadResponseWriter() http.ResponseWriter {
 	return bs.resp.ResponseWriter
 }
+
+//ReadRestfulResponse return a native go-restful Response
+func (bs *Context) ReadRestfulResponse() *restful.Response {
+	return bs.resp
+}

--- a/server/restful/restful_server.go
+++ b/server/restful/restful_server.go
@@ -140,7 +140,8 @@ func (r *restfulServer) Register(schema interface{}, options ...server.RegisterO
 				lager.Logger.Errorf(err, "transfer http request to invocation failed")
 				return
 			}
-			bs := NewBaseServer(context.TODO())
+			//give inv.ctx to user handlers, user may inject headers in handler chain
+			bs := NewBaseServer(inv.Ctx)
 			bs.req = req
 			bs.resp = rep
 			c.Next(inv, func(ir *invocation.Response) error {


### PR DESCRIPTION
add api for header, metadata in invocation 
unify headers to ctx
don not allocate mem for matadata or ctx map if user never use it, that is to improve perf
set inv ctx to restful handler